### PR TITLE
Correctly mocked beans created by factory beans

### DIFF
--- a/src/main/java/no/saua/remock/internal/RemockBeanFactory.java
+++ b/src/main/java/no/saua/remock/internal/RemockBeanFactory.java
@@ -91,7 +91,7 @@ public class RemockBeanFactory extends DefaultListableBeanFactory {
         } else if (bean instanceof FactoryBean) {
             FactoryBean<?> fb = (FactoryBean<?>) bean;
             if (isBeanRejected(beanName, fb.getObjectType())) {
-                log.info("Rejected FactoryBean[{}] beacause it would have created a [{}]", fb, fb.getObjectType());
+                log.info("Rejected FactoryBean[{}] because it would have created a [{}]", fb, fb.getObjectType());
             }
         } else {
             super.registerSingleton(beanName, bean);

--- a/src/test/java/no/saua/remock/ReplaceWithMockQualifierBeanFactoryTest.java
+++ b/src/test/java/no/saua/remock/ReplaceWithMockQualifierBeanFactoryTest.java
@@ -1,0 +1,164 @@
+package no.saua.remock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.UUID;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.test.context.ContextConfiguration;
+
+import no.saua.remock.ReplaceWithMockQualifierBeanFactoryTest.CampaignConfiguration;
+import no.saua.remock.ReplaceWithMockQualifierBeanFactoryTest.TheAnnotation.TheAnnotations;
+
+/**
+ * Similar to {@link ReplaceWithMockQualifierTest}, however, this test verifies that utilizing {@link ReplaceWithMock}
+ * with {@link Qualifier} also handles beans being created by a {@link FactoryBean}. In these cases the bean name will
+ * be linked to the {@link BeanDefinition} of the {@link FactoryBean} not the underlying type which the
+ * {@link FactoryBean}. The bean name isn't connected to the type created by the FactoryBean until the factory has
+ * produced an instance.
+ * <p>
+ * To summarize, this test verifies that the {@link BeanDefinition} for the field annotated with
+ * {@link Qualifier &#064;Qualifier("Steve")} isn't override by the {@link TheRealAnnotation_Factory} type. Step by
+ * step:
+ * <ul>
+ *     <li>Remock registered {@link BeanDefinition} for the field _theRealRealAnnotation of the type
+ *     {@link TheRealAnnotation} and named "Steve"</li>
+ *     <li>The {@link Configuration} class is processed {@link CampaignConfiguration} and thus the
+ *     {@link TheAnnotation}s are processed.</li>
+ *     <li>{@link TheAnnotation} are processed via {@link TheAnnotationSetup} which will attempt to register
+ *     {@link BeanDefinition}s with the underlying {@link BeanFactory}</li>
+ *     <li>The underlying {@link BeanFactory} should reject both because of type and because of the bean name for the
+ *     instance of "Steve"</li>
+ * </ul>
+ *
+ * @author Kevin Mc Tiernan, 2024-09-29, kevin.mc.tiernan@storebrand.no
+ */
+@ContextConfiguration(classes = CampaignConfiguration.class)
+public class ReplaceWithMockQualifierBeanFactoryTest extends CommonTest {
+
+    @ReplaceWithMock
+    private TheRealAnnotation _theRealAnnotation;
+    @ReplaceWithMock
+    @Qualifier("Steve")
+    private TheRealAnnotation _theRealRealAnnotation;
+
+    @Inject
+    private TheCampaign _theCampaign;
+
+    @Test
+    public void verifyQualifiedBeanDiffersFromNonQualified() {
+        Assert.assertNotEquals(_theCampaign._theRealAnnotation, _theCampaign._otherRealAnnotation);
+        Assert.assertEquals(_theRealAnnotation, _theCampaign._theRealAnnotation);
+        Assert.assertEquals(_theRealRealAnnotation, _theCampaign._otherRealAnnotation);
+
+        Mockito.when(_theRealAnnotation.getGreatestTradeDeal()).thenReturn("GameStop");
+        Mockito.when(_theRealRealAnnotation.getGreatestTradeDeal()).thenReturn("Nvidia");
+
+        Assert.assertNotEquals(_theRealAnnotation.getGreatestTradeDeal(),
+                _theRealRealAnnotation.getGreatestTradeDeal());
+    }
+
+    @Configuration
+    @TheAnnotation
+    @TheAnnotation(beanName = "Steve")
+    public static class CampaignConfiguration {
+
+        @Bean
+        public TheCampaign myCampaign(TheRealAnnotation realAnnotation,
+                @Named("Steve") TheRealAnnotation otherAnnon) {
+            return new TheCampaign(realAnnotation, otherAnnon);
+        }
+
+    }
+
+    public static class TheCampaign {
+        final TheRealAnnotation _theRealAnnotation;
+        final TheRealAnnotation _otherRealAnnotation;
+
+        public TheCampaign(TheRealAnnotation theRealAnnotation, TheRealAnnotation otherRealAnnotation) {
+            _theRealAnnotation = theRealAnnotation;
+            _otherRealAnnotation = otherRealAnnotation;
+        }
+    }
+
+    public static class TheRealAnnotation {
+
+        public String getGreatestTradeDeal() {
+            return null;
+        }
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @Repeatable(TheAnnotations.class)
+    @Import(TheAnnotationSetup.class)
+    public @interface TheAnnotation {
+
+        String beanName() default "";
+
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.TYPE)
+        @Import(TheAnnotationSetup.class)
+        public @interface TheAnnotations {
+            TheAnnotation[] value();
+        }
+    }
+
+    public static class TheAnnotationSetup implements ImportBeanDefinitionRegistrar {
+
+        @Override
+        public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
+                BeanDefinitionRegistry registry) {
+            AnnotationAttributes annotationAttributes = (AnnotationAttributes)
+                    importingClassMetadata.getAnnotationAttributes(TheAnnotations.class.getName());
+
+            AnnotationAttributes[] annonAttriArray = (AnnotationAttributes[]) annotationAttributes.get("value");
+
+            for (AnnotationAttributes attri : annonAttriArray) {
+                GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
+                beanDefinition.setBeanClass(TheRealAnnotation_Factory.class);
+
+                String beanName = (String) attri.get("beanName");
+                // ?: Is a beanName set? // -> Yes, then use this // -> No, use random UUID.
+                beanName = !"".equalsIgnoreCase(beanName) ? beanName : UUID.randomUUID().toString();
+                registry.registerBeanDefinition(beanName, beanDefinition);
+            }
+        }
+    }
+
+    public static class TheRealAnnotation_Factory extends AbstractFactoryBean<TheRealAnnotation> {
+
+        @Override
+        public Class<?> getObjectType() {
+            return TheRealAnnotation.class;
+        }
+
+        @Override
+        protected TheRealAnnotation createInstance() throws Exception {
+            return new TheRealAnnotation();
+        }
+    }
+
+}


### PR DESCRIPTION
When implementing support for @Qualifier in combination with @ReplaceWithMock it was discovered that beans being created via a factoryBean wouldn't be correctly mocked. This is because when registering the rejecter, we would only register the type and not the name of the bean (which was the point of the @Qualifier support), thus when a utilizing Annotations which register facoryBeans for a given type the name of the bean would be found RemockBeanFactory#registerBeanDefinition intercepted the registration, however, the type wouldn't match any of the rejectors and thus the default behavior is to override the existing beanDefinition present in the beanDefinition map.

To avoid this override behavior, we now register a rejecter of the type RejectBeanNameDefinition in cases where @Qualified is utilized in combination with @ReplaceWithMock. This ensures that we correctly reject FactorBean definitions.